### PR TITLE
[Not yet tested] Ability to load 3 dimensions worth of embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ total number of embedding in this folder
 
 #### .dimension
 
-dimension of one embedding
+dimension of one embedding (tuple of `(dim,)` for 1d embeddings or `(dim1, dim2)` for 2d embeddings)
 
 #### .byte_per_item
 

--- a/embedding_reader/numpy_reader.py
+++ b/embedding_reader/numpy_reader.py
@@ -24,14 +24,14 @@ def read_numpy_header(f):
     f.seek(0)
     file_size = f.size if isinstance(f.size, int) else f.size()
     first_line = f.read(min(file_size, 300)).split(b"\n")[0]
-    
+
     result = re.search(r"'shape': \(([0-9]+), ([0-9]+)(?:,\W([0-9]+))?\)", str(first_line))
     captures = result.groups()
     if captures[2] is not None:
         shape = (int(captures[0]), int(captures[1]), int(captures[2]))
     else:
         shape = (int(captures[0]), int(captures[1]))
-    
+
     dtype = re.search(r"'descr': '([<f0-9]+)'", str(first_line)).group(1)
     end = len(first_line) + 1  # the first line content and the endline
     f.seek(0)
@@ -81,9 +81,8 @@ class NumpyReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError(f"No embeddings found in folder {embeddings_folder}")
-        
+
         self.dimension = self.headers.iloc[0]["dimension"]
-        
         self.byte_per_item = self.headers.iloc[0]["byte_per_item"]
         self.dtype = self.headers.iloc[0]["dtype"]
         self.total_size = self.count * self.byte_per_item

--- a/embedding_reader/numpy_reader.py
+++ b/embedding_reader/numpy_reader.py
@@ -36,6 +36,10 @@ def read_numpy_header(f):
     end = len(first_line) + 1  # the first line content and the endline
     f.seek(0)
     byte_per_item = np.dtype(dtype).itemsize * shape[1]
+    
+    if len(shape) > 2:
+        byte_per_item *= shape[2]
+    
     return (shape[0], shape[1:], dtype, end, byte_per_item)
 
 

--- a/embedding_reader/parquet_numpy_reader.py
+++ b/embedding_reader/parquet_numpy_reader.py
@@ -47,7 +47,7 @@ class ParquetNumpyReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError("No embeddings found in folder {embeddings_folder}")
-        self.dimension = int(self.headers.iloc[0]["dimension"])
+        self.dimension = self.headers.iloc[0]["dimension"]
         self.byte_per_item = self.headers.iloc[0]["byte_per_item"]
         self.dtype = self.headers.iloc[0]["dtype"]
         self.total_size = self.count * self.byte_per_item
@@ -98,7 +98,7 @@ class ParquetNumpyReader:
                         None,
                         (
                             np.frombuffer(f.read(length * self.byte_per_item), dtype=self.dtype).reshape(
-                                (length, self.dimension)
+                                (length, *self.dimension)
                             ),
                             ids,
                             piece,
@@ -155,7 +155,7 @@ class ParquetNumpyReader:
                     ) from err
                 try:
                     if batch is None:
-                        batch = np.empty((piece.batch_length, self.dimension), "float32")
+                        batch = np.empty((piece.batch_length, *self.dimension), "float32")
                         batch_meta = np.empty((piece.batch_length, len(self.metadata_column_names)), dtype="object")
 
                     batch[batch_offset : (batch_offset + piece.piece_length)] = data

--- a/embedding_reader/parquet_reader.py
+++ b/embedding_reader/parquet_reader.py
@@ -56,7 +56,7 @@ class ParquetReader:
                 batches = parquet_file.iter_batches(batch_size=1, columns=[embedding_column_name])
                 try:
                     embedding = next(batches).to_pandas()[embedding_column_name].to_numpy()[0]
-                    self.dimension = int(embedding.shape[0])
+                    self.dimension = embedding.shape
                     break
                 except StopIteration:
                     continue
@@ -66,7 +66,7 @@ class ParquetReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError(f"No embeddings found in folder {embeddings_folder}")
-        self.byte_per_item = 4 * self.dimension
+        self.byte_per_item = 4 * self.dimension.size
 
         self.total_size = self.count * self.byte_per_item
 
@@ -142,7 +142,7 @@ class ParquetReader:
                     ) from err
                 try:
                     if batch is None:
-                        batch = np.empty((piece.batch_length, self.dimension), "float32")
+                        batch = np.empty((piece.batch_length, *self.dimension), "float32")
                         if self.metadata_column_names is not None:
                             batch_meta = np.empty((piece.batch_length, len(self.metadata_column_names)), dtype="object")
                     batch[batch_offset : (batch_offset + piece.piece_length)] = data

--- a/embedding_reader/parquet_reader.py
+++ b/embedding_reader/parquet_reader.py
@@ -66,7 +66,7 @@ class ParquetReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError(f"No embeddings found in folder {embeddings_folder}")
-        self.byte_per_item = 4 * self.dimension.size
+        self.byte_per_item = 4 * (self.dimension[0] * self.dimension[1])
 
         self.total_size = self.count * self.byte_per_item
 

--- a/embedding_reader/parquet_reader.py
+++ b/embedding_reader/parquet_reader.py
@@ -66,7 +66,7 @@ class ParquetReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError(f"No embeddings found in folder {embeddings_folder}")
-        
+
         if len(self.dimension) == 1:
             self.byte_per_item = 4 * self.dimension[0]
         else:

--- a/embedding_reader/parquet_reader.py
+++ b/embedding_reader/parquet_reader.py
@@ -66,7 +66,11 @@ class ParquetReader:
         self.count = self.headers["count"].sum()
         if self.count == 0:
             raise ValueError(f"No embeddings found in folder {embeddings_folder}")
-        self.byte_per_item = 4 * (self.dimension[0] * self.dimension[1])
+        
+        if len(self.dimension) == 1:
+            self.byte_per_item = 4 * self.dimension[0]
+        else:
+            self.byte_per_item = 4 * (self.dimension[0] * self.dimension[1])
 
         self.total_size = self.count * self.byte_per_item
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -33,7 +33,7 @@ def test_embedding_reader(file_format, collection_kind, tmpdir):
         metadata_folder=tmp_dir,
     )
 
-    assert embedding_reader.dimension == dim
+    assert embedding_reader.dimension == (dim,)
     assert embedding_reader.count == sum(sizes)
     assert embedding_reader.byte_per_item == dim * 4
     assert embedding_reader.total_size == embedding_reader.count * embedding_reader.byte_per_item


### PR DESCRIPTION
This feature would be useful for scripts such as ClipCap that may need to load multiple patches worth of embeddings per sample, i.e. `(batch, patches, dim)` instead of `(batch, dim)`.

I have not yet tested this (especially with the parquet reader, however, this is using some of the code used previously before the ClipCap rewrite. Will try it out on a numpy reader just to verify it all works okay shortly.

This also changes `reader.dimension` from an int to a tuple of either `(dim,)` or `(dim1, dim2)`.

Is this worthy of a PR or would this be more suitable as just a modified version of the parquet_numpy_reader on ClipCap's end to avoid complication?
