### PR TITLE
Fix to ValueError raised on Windows when this function is run (https://github.com/criteo/autofaiss/issues/113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -28,7 +28,7 @@ jobs:
           source .env/bin/activate
           make lint
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/embedding_reader/get_file_list.py
+++ b/embedding_reader/get_file_list.py
@@ -41,7 +41,7 @@ def _get_file_list(
     """Get the file system and all the file paths that matches `file_format` given a single path."""
     path = make_path_absolute(path)
     fs, path_in_fs = fsspec.core.url_to_fs(path)
-    prefix = path[: path.index(path_in_fs)]
+    prefix = path[: -len(path_in_fs)]
     glob_pattern = path.rstrip("/") + f"/**.{file_format}"
     file_paths = fs.glob(glob_pattern)
     if sort_result:


### PR DESCRIPTION
path.index in your code would always result in a ValueError on windows machines because the paths have reversed backslashes. With this fix its compatible with any path no matter which way the backslashes are facing.