### PR TITLE
Make library installable in python3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ tqdm>=4.62.3,<5
 fsspec>=2022.1.0
 numpy>=1.19.5,<2
 pandas>=1.1.5,<2
-pyarrow>=6.0.1,<8; python_version < "3.11"
-pyarrow>=11,<13; python_version >= "3.11"
+pyarrow>=6.0.1,<13

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ tqdm>=4.62.3,<5
 fsspec>=2022.1.0
 numpy>=1.19.5,<2
 pandas>=1.1.5,<2
-pyarrow>=6.0.1,<8
+pyarrow>=6.0.1,<8; python_version < "3.11"
+pyarrow>=11,<13; python_version >= "3.11"


### PR DESCRIPTION
(No wheel available for pyarrow<8 in python 3.11)