### PR TITLE
Fix glob path in get_file_list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/embedding_reader/get_file_list.py
+++ b/embedding_reader/get_file_list.py
@@ -42,7 +42,7 @@ def _get_file_list(
     path = make_path_absolute(path)
     fs, path_in_fs = fsspec.core.url_to_fs(path)
     prefix = path[: -len(path_in_fs)]
-    glob_pattern = path.rstrip("/") + f"/**.{file_format}"
+    glob_pattern = path.rstrip("/") + f"/**/*.{file_format}"
     file_paths = fs.glob(glob_pattern)
     if sort_result:
         file_paths.sort()

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ if __name__ == "__main__":
             "Intended Audience :: Developers",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
             "License :: OSI Approved :: MIT License",
-            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.8",
         ],
     )


### PR DESCRIPTION
The 2023.12.0 [release](https://github.com/fsspec/filesystem_spec/releases/tag/2023.12.0) of fsspec introduced a [change](https://github.com/fsspec/filesystem_spec/pull/1382) to the globbing of `**`. As a result, `get_file_list` is broken:
```python
from embedding_reader.get_file_list import get_file_list
get_file_list(".", "py")
```
raises
```
ValueError: Invalid pattern: '**' can only be an entire path component
```
This PR fixes this issue by changing `**.{file_format}` to `**/*.{file_format}`, which should be backwards-compatible.