### PR TITLE
Add requirements.txt to sdist, remove README.md from data_files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ if __name__ == "__main__":
         author="Romain Beaumont",
         author_email="romain.rom1@gmail.com",
         url="https://github.com/rom1504/embedding-reader",
-        data_files=[(".", ["README.md"])],
         keywords=["machine learning"],
         install_requires=REQUIREMENTS,
         classifiers=[


### PR DESCRIPTION
Fixes #47.

- `requirements.txt` being missing from the source tarball meant that this package was only possible to install from the wheel, not from the sdist; one can reproduce the problem by using `--no-binary :all:` as an argument to `pip`.
- Adding `README.md` to `data_files` meant that it was installed into site-packages instead of only being added to the source tarball; being at the root, it conflicted with any _other_ Python package trying to install a README.md when using a package manager that tracks such conflicts.